### PR TITLE
Add legacy Python support

### DIFF
--- a/Bootup Logos/README.md
+++ b/Bootup Logos/README.md
@@ -1,6 +1,6 @@
 # Boot up Logos
 
-## Boot up logo's are logos or animations shown on boot of IronOS
+## Boot up logos are logos or animations shown on boot of IronOS
 
 These are programmed into the device just like the normal firmware.
 They can be (re)programmed as many times as desired, after flashing the normal firmware.

--- a/Bootup Logos/img2logo.py
+++ b/Bootup Logos/img2logo.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
+from __future__ import annotations
 from __future__ import division
 import argparse
 import copy


### PR DESCRIPTION
Adds support for legacy Python builds such as 3.8.20 so that operating systems which cannot run 3.9 can still use the img2logo script.