### PR TITLE
Fixup! PinecilV2 use XIP address

### DIFF
--- a/Bootup Logos/img2logo.py
+++ b/Bootup Logos/img2logo.py
@@ -81,7 +81,9 @@ class PinecilSettings:
 
 
 class Pinecilv2Settings:
-    IMAGE_ADDRESS = 1016 * 1024  # its 2 4k erase pages inset
+    IMAGE_ADDRESS = 0x23000000 + (
+        1016 * 1024
+    )  # its 2 4k erase pages inset from the end, + XIP offset
     DFU_TARGET_NAME = b"Pinecilv2"
     DFU_ALT = 0
     DFU_VENDOR = 0x28E9  # These are ignored by blisp so doesnt matter what we use


### PR DESCRIPTION
We can technically flash from 0x0 or the XIP base.
Move to using the XIP base to keep it matching firmware.

Fixes #54 i believe